### PR TITLE
chore(deps): update all dependencies to latest

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -18,11 +18,11 @@ jobs:
       directories: ${{ steps.dirs.outputs.directories }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Get root directories
         id: dirs
-        uses: clowdhaus/terraform-composite-actions/directories@v1.11.1
+        uses: clowdhaus/terraform-composite-actions/directories@v1.14.0
 
   preCommitMinVersions:
     name: Min TF pre-commit
@@ -33,18 +33,18 @@ jobs:
         directory: ${{ fromJson(needs.collectInputs.outputs.directories) }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Terraform min/max versions
         id: minMax
-        uses: clowdhaus/terraform-min-max@v1.3.2
+        uses: clowdhaus/terraform-min-max@v3.0.1
         with:
           directory: ${{ matrix.directory }}
 
       - name: Pre-commit Terraform ${{ steps.minMax.outputs.minVersion }}
         # Run only validate pre-commit check on min version supported
         if: ${{ matrix.directory !=  '.' }}
-        uses: clowdhaus/terraform-composite-actions/pre-commit@v1.11.1
+        uses: clowdhaus/terraform-composite-actions/pre-commit@v1.14.0
         with:
           terraform-version: ${{ steps.minMax.outputs.minVersion }}
           tflint-version: ${{ env.TFLINT_VERSION }}
@@ -53,7 +53,7 @@ jobs:
       - name: Pre-commit Terraform ${{ steps.minMax.outputs.minVersion }}
         # Run only validate pre-commit check on min version supported
         if: ${{ matrix.directory ==  '.' }}
-        uses: clowdhaus/terraform-composite-actions/pre-commit@v1.11.1
+        uses: clowdhaus/terraform-composite-actions/pre-commit@v1.14.0
         with:
           terraform-version: ${{ steps.minMax.outputs.minVersion }}
           tflint-version: ${{ env.TFLINT_VERSION }}
@@ -65,17 +65,17 @@ jobs:
     needs: collectInputs
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: ${{ github.event.pull_request.head.ref }}
           repository: ${{github.event.pull_request.head.repo.full_name}}
 
       - name: Terraform min/max versions
         id: minMax
-        uses: clowdhaus/terraform-min-max@v1.3.2
+        uses: clowdhaus/terraform-min-max@v3.0.1
 
       - name: Pre-commit Terraform ${{ steps.minMax.outputs.maxVersion }}
-        uses: clowdhaus/terraform-composite-actions/pre-commit@v1.11.1
+        uses: clowdhaus/terraform-composite-actions/pre-commit@v1.14.0
         with:
           terraform-version: ${{ steps.minMax.outputs.maxVersion }}
           tflint-version: ${{ env.TFLINT_VERSION }}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/antonbabenko/pre-commit-terraform
-    rev: v1.91.0
+    rev: v1.106.0
     hooks:
       - id: terraform_fmt
       - id: terraform_validate
@@ -21,7 +21,7 @@ repos:
           - '--args=--only=terraform_unused_required_providers'
           - '--args=--only=terraform_workspace_remote'
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.6.0
+    rev: v6.0.0
     hooks:
       - id: check-merge-conflict
       - id: end-of-file-fixer

--- a/cluster-autoscaler/add-ons.tf
+++ b/cluster-autoscaler/add-ons.tf
@@ -4,7 +4,7 @@
 
 module "eks_blueprints_addons" {
   source  = "aws-ia/eks-blueprints-addons/aws"
-  version = "~> 1.16"
+  version = "~> 1.23"
 
   cluster_name      = module.eks.cluster_name
   cluster_endpoint  = module.eks.cluster_endpoint

--- a/cluster-autoscaler/eks.tf
+++ b/cluster-autoscaler/eks.tf
@@ -4,19 +4,19 @@
 
 module "eks" {
   source  = "terraform-aws-modules/eks/aws"
-  version = "~> 20.5"
+  version = "~> 21.0"
 
-  cluster_name    = local.name
-  cluster_version = "1.29"
+  name               = local.name
+  kubernetes_version = "1.29"
 
   # To facilitate easier interaction for demonstration purposes
-  cluster_endpoint_public_access = true
+  endpoint_public_access = true
 
   # Gives Terraform identity admin access to cluster which will
   # allow deploying resources (Karpenter) into the cluster
   enable_cluster_creator_admin_permissions = true
 
-  cluster_addons = {
+  addons = {
     coredns    = {}
     kube-proxy = {}
     vpc-cni    = {}
@@ -25,13 +25,6 @@ module "eks" {
   vpc_id     = module.vpc.vpc_id
   subnet_ids = module.vpc.private_subnets
 
-  eks_managed_node_group_defaults = {
-    iam_role_additional_policies = {
-      # Not required, but used in the example to access the nodes to inspect drivers and devices
-      AmazonSSMManagedInstanceCore = "arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore"
-    }
-  }
-
   eks_managed_node_groups = {
     default = {
       instance_types = ["m5.large"]
@@ -39,6 +32,11 @@ module "eks" {
       min_size     = 1
       max_size     = 20
       desired_size = 1
+
+      iam_role_additional_policies = {
+        # Not required, but used in the example to access the nodes to inspect drivers and devices
+        AmazonSSMManagedInstanceCore = "arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore"
+      }
 
       launch_template_tags = {
         "k8s.io/cluster-autoscaler/enabled" : true,

--- a/cluster-autoscaler/main.tf
+++ b/cluster-autoscaler/main.tf
@@ -1,14 +1,14 @@
 terraform {
-  required_version = ">= 1.3.2"
+  required_version = ">= 1.5.7"
 
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.40"
+      version = ">= 6.0"
     }
     helm = {
       source  = "hashicorp/helm"
-      version = ">= 2.7"
+      version = "~> 2.17"
     }
   }
 }
@@ -61,7 +61,7 @@ data "aws_availability_zones" "available" {}
 
 module "tags" {
   source  = "clowdhaus/tags/aws"
-  version = "~> 1.0"
+  version = "~> 2.0"
 
   application = local.name
   environment = local.environment

--- a/cluster-autoscaler/vpc.tf
+++ b/cluster-autoscaler/vpc.tf
@@ -5,7 +5,7 @@
 module "vpc" {
   # https://registry.terraform.io/modules/terraform-aws-modules/vpc/aws/latest
   source  = "terraform-aws-modules/vpc/aws"
-  version = "~> 5.0"
+  version = "~> 6.0"
 
   name = local.name
   cidr = local.vpc_cidr

--- a/does-not-work/eks-mng-ssm-param/eks.tf
+++ b/does-not-work/eks-mng-ssm-param/eks.tf
@@ -4,15 +4,15 @@ locals {
 
 module "eks_al2" {
   source  = "terraform-aws-modules/eks/aws"
-  version = "~> 20.0"
+  version = "~> 21.0"
 
-  cluster_name    = local.name
-  cluster_version = local.cluster_version
+  name               = local.name
+  kubernetes_version = local.cluster_version
 
   enable_cluster_creator_admin_permissions = true
 
   # EKS Addons
-  cluster_addons = {
+  addons = {
     coredns    = {}
     kube-proxy = {}
     vpc-cni    = {}

--- a/does-not-work/eks-mng-ssm-param/main.tf
+++ b/does-not-work/eks-mng-ssm-param/main.tf
@@ -1,10 +1,10 @@
 terraform {
-  required_version = ">= 1.3.2"
+  required_version = ">= 1.5.7"
 
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.40"
+      version = ">= 6.0"
     }
   }
 
@@ -52,7 +52,7 @@ data "aws_availability_zones" "available" {}
 
 module "tags" {
   source  = "clowdhaus/tags/aws"
-  version = "~> 1.0"
+  version = "~> 2.0"
 
   application = local.name
   environment = local.environment

--- a/does-not-work/eks-mng-ssm-param/vpc.tf
+++ b/does-not-work/eks-mng-ssm-param/vpc.tf
@@ -1,7 +1,7 @@
 module "vpc" {
   # https://registry.terraform.io/modules/terraform-aws-modules/vpc/aws/latest
   source  = "terraform-aws-modules/vpc/aws"
-  version = "~> 5.0"
+  version = "~> 6.0"
 
   name = local.name
   cidr = local.vpc_cidr

--- a/eks-managed-node-group/eks_al2.tf
+++ b/eks-managed-node-group/eks_al2.tf
@@ -1,12 +1,12 @@
 module "eks_al2" {
   source  = "terraform-aws-modules/eks/aws"
-  version = "~> 20.0"
+  version = "~> 21.0"
 
-  cluster_name    = "${local.name}-al2"
-  cluster_version = "1.29"
+  name               = "${local.name}-al2"
+  kubernetes_version = "1.29"
 
   # EKS Addons
-  cluster_addons = {
+  addons = {
     # aws-ebs-csi-driver = {}
     coredns    = {}
     kube-proxy = {}

--- a/eks-managed-node-group/eks_bottlerocket.tf
+++ b/eks-managed-node-group/eks_bottlerocket.tf
@@ -1,12 +1,12 @@
 module "eks_bottlerocket" {
   source  = "terraform-aws-modules/eks/aws"
-  version = "~> 20.0"
+  version = "~> 21.0"
 
-  cluster_name    = "${local.name}-br"
-  cluster_version = "1.29"
+  name               = "${local.name}-br"
+  kubernetes_version = "1.29"
 
   # EKS Addons
-  cluster_addons = {
+  addons = {
     # aws-ebs-csi-driver = {}
     coredns    = {}
     kube-proxy = {}

--- a/eks-managed-node-group/eks_default.tf
+++ b/eks-managed-node-group/eks_default.tf
@@ -1,12 +1,12 @@
 module "eks_default" {
   source  = "terraform-aws-modules/eks/aws"
-  version = "~> 20.0"
+  version = "~> 21.0"
 
-  cluster_name    = "${local.name}-default"
-  cluster_version = "1.29"
+  name               = "${local.name}-default"
+  kubernetes_version = "1.29"
 
   # EKS Addons
-  cluster_addons = {
+  addons = {
     # aws-ebs-csi-driver = {}
     coredns    = {}
     kube-proxy = {}

--- a/eks-managed-node-group/main.tf
+++ b/eks-managed-node-group/main.tf
@@ -1,10 +1,10 @@
 terraform {
-  required_version = ">= 1.3.2"
+  required_version = ">= 1.5.7"
 
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.40"
+      version = ">= 6.0"
     }
   }
 
@@ -52,7 +52,7 @@ data "aws_availability_zones" "available" {}
 
 module "tags" {
   source  = "clowdhaus/tags/aws"
-  version = "~> 1.0"
+  version = "~> 2.0"
 
   application = local.name
   environment = local.environment

--- a/eks-managed-node-group/vpc.tf
+++ b/eks-managed-node-group/vpc.tf
@@ -1,7 +1,7 @@
 module "vpc" {
   # https://registry.terraform.io/modules/terraform-aws-modules/vpc/aws/latest
   source  = "terraform-aws-modules/vpc/aws"
-  version = "~> 5.0"
+  version = "~> 6.0"
 
   name = local.name
   cidr = local.vpc_cidr

--- a/eks-mng-gpu/eks.tf
+++ b/eks-mng-gpu/eks.tf
@@ -4,20 +4,20 @@ locals {
 
 module "eks" {
   source  = "terraform-aws-modules/eks/aws"
-  version = "~> 20.0"
+  version = "~> 21.0"
 
-  cluster_name    = local.name
-  cluster_version = "1.29"
+  name               = local.name
+  kubernetes_version = "1.29"
 
   # To facilitate easier interaction for demonstration purposes
-  cluster_endpoint_public_access = true
+  endpoint_public_access = true
 
   # Gives Terraform identity admin access to cluster which will
   # allow deploying resources into the cluster
   enable_cluster_creator_admin_permissions = true
 
   # EKS Addons
-  cluster_addons = {
+  addons = {
     coredns    = {}
     kube-proxy = {}
     vpc-cni    = {}
@@ -25,13 +25,6 @@ module "eks" {
 
   vpc_id     = module.vpc.vpc_id
   subnet_ids = module.vpc.private_subnets
-
-  eks_managed_node_group_defaults = {
-    iam_role_additional_policies = {
-      # Not required, but used in the example to access the nodes to inspect drivers and devices
-      AmazonSSMManagedInstanceCore = "arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore"
-    }
-  }
 
   eks_managed_node_groups = {
     # This node group is for core addons such as CoreDNS
@@ -41,6 +34,11 @@ module "eks" {
       min_size     = 1
       max_size     = 2
       desired_size = 2
+
+      iam_role_additional_policies = {
+        # Not required, but used in the example to access the nodes to inspect drivers and devices
+        AmazonSSMManagedInstanceCore = "arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore"
+      }
     }
 
     gpu = {
@@ -50,6 +48,11 @@ module "eks" {
       min_size     = 1
       max_size     = 1
       desired_size = 1
+
+      iam_role_additional_policies = {
+        # Not required, but used in the example to access the nodes to inspect drivers and devices
+        AmazonSSMManagedInstanceCore = "arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore"
+      }
 
       # Default AMI has only 8GB of storage
       block_device_mappings = {
@@ -85,7 +88,7 @@ resource "helm_release" "nvidia_device_plugin" {
   name             = "nvidia-device-plugin"
   repository       = "https://nvidia.github.io/k8s-device-plugin"
   chart            = "nvidia-device-plugin"
-  version          = "0.17.1"
+  version          = "0.19.2"
   namespace        = "nvidia-device-plugin"
   create_namespace = true
   wait             = false

--- a/eks-mng-gpu/main.tf
+++ b/eks-mng-gpu/main.tf
@@ -1,14 +1,14 @@
 terraform {
-  required_version = ">= 1.3.2"
+  required_version = ">= 1.5.7"
 
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.40"
+      version = ">= 6.0"
     }
     helm = {
       source  = "hashicorp/helm"
-      version = ">= 2.7"
+      version = ">= 3.0"
     }
   }
 }
@@ -23,11 +23,11 @@ provider "aws" {
 }
 
 provider "helm" {
-  kubernetes {
+  kubernetes = {
     host                   = module.eks.cluster_endpoint
     cluster_ca_certificate = base64decode(module.eks.cluster_certificate_authority_data)
 
-    exec {
+    exec = {
       api_version = "client.authentication.k8s.io/v1beta1"
       command     = "aws"
       # This requires the awscli to be installed locally where Terraform is executed
@@ -61,7 +61,7 @@ data "aws_availability_zones" "available" {}
 
 module "tags" {
   source  = "clowdhaus/tags/aws"
-  version = "~> 1.0"
+  version = "~> 2.0"
 
   application = local.name
   environment = local.environment

--- a/eks-mng-gpu/vpc.tf
+++ b/eks-mng-gpu/vpc.tf
@@ -1,7 +1,7 @@
 module "vpc" {
   # https://registry.terraform.io/modules/terraform-aws-modules/vpc/aws/latest
   source  = "terraform-aws-modules/vpc/aws"
-  version = "~> 5.0"
+  version = "~> 6.0"
 
   name = local.name
   cidr = local.vpc_cidr

--- a/ephemeral-vol-test/eks.tf
+++ b/ephemeral-vol-test/eks.tf
@@ -1,16 +1,16 @@
 module "eks" {
   source  = "terraform-aws-modules/eks/aws"
-  version = "~> 20.0"
+  version = "~> 21.0"
 
-  cluster_name    = local.name
-  cluster_version = "1.29"
+  name               = local.name
+  kubernetes_version = "1.29"
 
-  cluster_endpoint_public_access = true
+  endpoint_public_access = true
 
   # EKS Addons
-  cluster_addons = {
+  addons = {
     aws-ebs-csi-driver = {
-      service_account_role_arn = module.ebs_csi_driver_irsa.iam_role_arn
+      service_account_role_arn = module.ebs_csi_driver_irsa.arn
     }
     coredns    = {}
     kube-proxy = {}
@@ -34,11 +34,12 @@ module "eks" {
 }
 
 module "ebs_csi_driver_irsa" {
-  source  = "terraform-aws-modules/iam/aws//modules/iam-role-for-service-accounts-eks"
-  version = "~> 5.20"
+  source  = "terraform-aws-modules/iam/aws//modules/iam-role-for-service-accounts"
+  version = "~> 6.0"
 
   # create_role      = false
-  role_name_prefix = "${module.eks.cluster_name}-ebs-csi-driver-"
+  name            = "${module.eks.cluster_name}-ebs-csi-driver-"
+  use_name_prefix = true
 
   attach_ebs_csi_policy = true
 

--- a/ephemeral-vol-test/main.tf
+++ b/ephemeral-vol-test/main.tf
@@ -1,10 +1,10 @@
 terraform {
-  required_version = ">= 1.3.2"
+  required_version = ">= 1.5.7"
 
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.40"
+      version = ">= 6.0"
     }
   }
 
@@ -52,7 +52,7 @@ data "aws_availability_zones" "available" {}
 
 module "tags" {
   source  = "clowdhaus/tags/aws"
-  version = "~> 1.0"
+  version = "~> 2.0"
 
   application = local.name
   environment = local.environment

--- a/ephemeral-vol-test/vpc.tf
+++ b/ephemeral-vol-test/vpc.tf
@@ -1,7 +1,7 @@
 module "vpc" {
   # https://registry.terraform.io/modules/terraform-aws-modules/vpc/aws/latest
   source  = "terraform-aws-modules/vpc/aws"
-  version = "~> 5.0"
+  version = "~> 6.0"
 
   name = local.name
   cidr = local.vpc_cidr

--- a/inferentia/add-ons.tf
+++ b/inferentia/add-ons.tf
@@ -4,7 +4,7 @@
 
 module "eks_blueprints_addons" {
   source  = "aws-ia/eks-blueprints-addons/aws"
-  version = "~> 1.16"
+  version = "~> 1.23"
 
   cluster_name      = module.eks.cluster_name
   cluster_endpoint  = module.eks.cluster_endpoint

--- a/inferentia/eks.tf
+++ b/inferentia/eks.tf
@@ -4,19 +4,19 @@
 
 module "eks" {
   source  = "terraform-aws-modules/eks/aws"
-  version = "~> 20.4"
+  version = "~> 21.0"
 
-  cluster_name    = local.name
-  cluster_version = "1.29"
+  name               = local.name
+  kubernetes_version = "1.29"
 
   # To facilitate easier interaction for demonstration purposes
-  cluster_endpoint_public_access = true
+  endpoint_public_access = true
 
   # Gives Terraform identity admin access to cluster which will
   # allow deploying resources (Karpenter) into the cluster
   enable_cluster_creator_admin_permissions = true
 
-  cluster_addons = {
+  addons = {
     coredns    = {}
     kube-proxy = {}
     vpc-cni    = {}
@@ -24,13 +24,6 @@ module "eks" {
 
   vpc_id     = module.vpc.vpc_id
   subnet_ids = module.vpc.private_subnets
-
-  eks_managed_node_group_defaults = {
-    iam_role_additional_policies = {
-      # Not required, but used in the example to access the nodes to inspect drivers and devices
-      AmazonSSMManagedInstanceCore = "arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore"
-    }
-  }
 
   eks_managed_node_groups = {
     # This node group is for core addons such as CoreDNS
@@ -40,6 +33,11 @@ module "eks" {
       min_size     = 1
       max_size     = 2
       desired_size = 2
+
+      iam_role_additional_policies = {
+        # Not required, but used in the example to access the nodes to inspect drivers and devices
+        AmazonSSMManagedInstanceCore = "arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore"
+      }
     }
 
     inferentia = {
@@ -49,6 +47,11 @@ module "eks" {
       min_size     = 1
       max_size     = 1
       desired_size = 1
+
+      iam_role_additional_policies = {
+        # Not required, but used in the example to access the nodes to inspect drivers and devices
+        AmazonSSMManagedInstanceCore = "arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore"
+      }
 
       # Default AMI has only 8GB of storage
       block_device_mappings = {

--- a/inferentia/main.tf
+++ b/inferentia/main.tf
@@ -1,22 +1,22 @@
 terraform {
-  required_version = ">= 1.3.2"
+  required_version = ">= 1.5.7"
 
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.40"
+      version = ">= 6.0"
     }
     helm = {
       source  = "hashicorp/helm"
-      version = ">= 2.7"
+      version = "~> 2.17"
     }
     http = {
       source  = "hashicorp/http"
-      version = ">= 3.3"
+      version = ">= 3.6"
     }
     kubectl = {
       source  = "alekc/kubectl"
-      version = ">= 2.0"
+      version = ">= 2.4"
     }
   }
 }
@@ -83,7 +83,7 @@ data "aws_availability_zones" "available" {}
 
 module "tags" {
   source  = "clowdhaus/tags/aws"
-  version = "~> 1.0"
+  version = "~> 2.0"
 
   application = local.name
   environment = local.environment

--- a/inferentia/vpc.tf
+++ b/inferentia/vpc.tf
@@ -1,7 +1,7 @@
 module "vpc" {
   # https://registry.terraform.io/modules/terraform-aws-modules/vpc/aws/latest
   source  = "terraform-aws-modules/vpc/aws"
-  version = "~> 5.0"
+  version = "~> 6.0"
 
   name = local.name
   cidr = local.vpc_cidr

--- a/ipv4-prefix-delegation/eks.tf
+++ b/ipv4-prefix-delegation/eks.tf
@@ -1,14 +1,14 @@
 module "eks" {
   source  = "terraform-aws-modules/eks/aws"
-  version = "~> 20.0"
+  version = "~> 21.0"
 
-  cluster_name    = local.name
-  cluster_version = "1.29"
+  name               = local.name
+  kubernetes_version = "1.29"
 
-  cluster_endpoint_public_access = true
+  endpoint_public_access = true
 
   # EKS Addons
-  cluster_addons = {
+  addons = {
     coredns    = {}
     kube-proxy = {}
     vpc-cni = {

--- a/ipv4-prefix-delegation/main.tf
+++ b/ipv4-prefix-delegation/main.tf
@@ -1,10 +1,10 @@
 terraform {
-  required_version = ">= 1.3.2"
+  required_version = ">= 1.5.7"
 
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.40"
+      version = ">= 6.0"
     }
   }
 
@@ -52,7 +52,7 @@ data "aws_availability_zones" "available" {}
 
 module "tags" {
   source  = "clowdhaus/tags/aws"
-  version = "~> 1.0"
+  version = "~> 2.0"
 
   application = local.name
   environment = local.environment

--- a/ipv4-prefix-delegation/vpc.tf
+++ b/ipv4-prefix-delegation/vpc.tf
@@ -1,7 +1,7 @@
 module "vpc" {
   # https://registry.terraform.io/modules/terraform-aws-modules/vpc/aws/latest
   source  = "terraform-aws-modules/vpc/aws"
-  version = "~> 5.0"
+  version = "~> 6.0"
 
   name = local.name
   cidr = local.vpc_cidr

--- a/ipvs/eks.tf
+++ b/ipvs/eks.tf
@@ -1,14 +1,14 @@
 module "eks" {
   source  = "terraform-aws-modules/eks/aws"
-  version = "~> 20.0"
+  version = "~> 21.0"
 
-  cluster_name    = local.name
-  cluster_version = "1.29"
+  name               = local.name
+  kubernetes_version = "1.29"
 
-  cluster_endpoint_public_access = true
+  endpoint_public_access = true
 
   # EKS Addons
-  cluster_addons = {
+  addons = {
     coredns = {}
     kube-proxy = {
       most_recent = true

--- a/ipvs/main.tf
+++ b/ipvs/main.tf
@@ -1,10 +1,10 @@
 terraform {
-  required_version = ">= 1.3.2"
+  required_version = ">= 1.5.7"
 
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.40"
+      version = ">= 6.0"
     }
   }
 
@@ -52,7 +52,7 @@ data "aws_availability_zones" "available" {}
 
 module "tags" {
   source  = "clowdhaus/tags/aws"
-  version = "~> 1.0"
+  version = "~> 2.0"
 
   application = local.name
   environment = local.environment

--- a/ipvs/vpc.tf
+++ b/ipvs/vpc.tf
@@ -1,7 +1,7 @@
 module "vpc" {
   # https://registry.terraform.io/modules/terraform-aws-modules/vpc/aws/latest
   source  = "terraform-aws-modules/vpc/aws"
-  version = "~> 5.0"
+  version = "~> 6.0"
 
   name = local.name
   cidr = local.vpc_cidr

--- a/karpenter-gpu/add-ons.tf
+++ b/karpenter-gpu/add-ons.tf
@@ -8,7 +8,7 @@ data "aws_ecrpublic_authorization_token" "this" {
 
 module "eks_blueprints_addons" {
   source  = "aws-ia/eks-blueprints-addons/aws"
-  version = "~> 1.0"
+  version = "~> 1.23"
 
   cluster_name      = module.eks.cluster_name
   cluster_endpoint  = module.eks.cluster_endpoint

--- a/karpenter-gpu/eks.tf
+++ b/karpenter-gpu/eks.tf
@@ -4,16 +4,16 @@
 
 module "eks" {
   source  = "terraform-aws-modules/eks/aws"
-  version = "~> 19.15"
+  version = "~> 21.0"
 
-  cluster_name    = local.name
-  cluster_version = "1.27"
+  name               = local.name
+  kubernetes_version = "1.27"
 
-  cluster_endpoint_public_access = true
+  endpoint_public_access = true
 
-  cluster_addons = {
+  addons = {
     aws-ebs-csi-driver = {
-      service_account_role_arn = module.ebs_csi_driver_irsa.iam_role_arn
+      service_account_role_arn = module.ebs_csi_driver_irsa.arn
     }
     coredns    = {}
     kube-proxy = {}
@@ -23,18 +23,11 @@ module "eks" {
   vpc_id     = module.vpc.vpc_id
   subnet_ids = module.vpc.private_subnets
 
-  manage_aws_auth_configmap = true
-  aws_auth_roles = [
-    # Karpenter node IAM role for nodes launched by Karpenter
-    {
-      rolearn  = module.eks_blueprints_addons.karpenter.node_iam_role_arn
-      username = "system:node:{{EC2PrivateDNSName}}"
-      groups = [
-        "system:bootstrappers",
-        "system:nodes",
-      ]
-    },
-  ]
+  # NOTE: aws-auth configmap support removed in v21; an access_entry referencing
+  # module.eks_blueprints_addons.karpenter.node_iam_role_arn creates a dependency
+  # cycle with the addons module. Karpenter node access needs to be wired via
+  # an externally-managed role or by migrating karpenter management out of
+  # aws-ia/eks-blueprints-addons. Left for operator follow-up.
 
   eks_managed_node_groups = {
     default = {
@@ -55,10 +48,12 @@ module "eks" {
 }
 
 module "ebs_csi_driver_irsa" {
-  source  = "terraform-aws-modules/iam/aws//modules/iam-role-for-service-accounts-eks"
-  version = "~> 5.20"
+  source  = "terraform-aws-modules/iam/aws//modules/iam-role-for-service-accounts"
+  version = "~> 6.0"
 
-  role_name_prefix = "${module.eks.cluster_name}-ebs-csi-driver-"
+  name = "${module.eks.cluster_name}-ebs-csi-driver-"
+
+  use_name_prefix = true
 
   attach_ebs_csi_policy = true
 

--- a/karpenter-gpu/main.tf
+++ b/karpenter-gpu/main.tf
@@ -1,22 +1,22 @@
 terraform {
-  required_version = ">= 1.3.2"
+  required_version = ">= 1.5.7"
 
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.40"
+      version = ">= 6.0"
     }
     helm = {
       source  = "hashicorp/helm"
-      version = ">= 2.6"
+      version = "~> 2.17"
     }
     kubectl = {
       source  = "alekc/kubectl"
-      version = ">= 2.0.0"
+      version = ">= 2.4"
     }
     kubernetes = {
       source  = "hashicorp/kubernetes"
-      version = ">= 2.20"
+      version = ">= 3.0"
     }
   }
 
@@ -100,7 +100,7 @@ data "aws_availability_zones" "available" {}
 
 module "tags" {
   source  = "clowdhaus/tags/aws"
-  version = "~> 1.0"
+  version = "~> 2.0"
 
   application = local.name
   environment = local.environment

--- a/karpenter-gpu/vpc.tf
+++ b/karpenter-gpu/vpc.tf
@@ -1,7 +1,7 @@
 module "vpc" {
   # https://registry.terraform.io/modules/terraform-aws-modules/vpc/aws/latest
   source  = "terraform-aws-modules/vpc/aws"
-  version = "~> 5.0"
+  version = "~> 6.0"
 
   name = local.name
   cidr = local.vpc_cidr

--- a/karpenter/alb_controller.tf
+++ b/karpenter/alb_controller.tf
@@ -3,10 +3,10 @@
 ################################################################################
 
 module "alb_controller_irsa" {
-  source  = "terraform-aws-modules/iam/aws//modules/iam-role-for-service-accounts-eks"
-  version = "~> 5.20"
+  source  = "terraform-aws-modules/iam/aws//modules/iam-role-for-service-accounts"
+  version = "~> 6.0"
 
-  role_name                              = "alb-controller-${local.name}"
+  name                                   = "alb-controller-${local.name}"
   attach_load_balancer_controller_policy = true
 
   oidc_providers = {
@@ -29,25 +29,24 @@ resource "helm_release" "alb_controller" {
   name       = "aws-load-balancer-controller"
   repository = "https://aws.github.io/eks-charts"
   chart      = "aws-load-balancer-controller"
-  version    = "1.13.3"
+  version    = "3.3.0"
 
-  set {
-    name  = "serviceAccount.annotations.eks\\.amazonaws\\.com/role-arn"
-    value = module.alb_controller_irsa.iam_role_arn
-  }
-
-  set {
-    name  = "clusterName"
-    value = module.eks.cluster_name
-  }
-
-  set {
-    name  = "region"
-    value = local.region
-  }
-
-  set {
-    name  = "vpcId"
-    value = module.vpc.vpc_id
-  }
+  set = [
+    {
+      name  = "serviceAccount.annotations.eks\\.amazonaws\\.com/role-arn"
+      value = module.alb_controller_irsa.arn
+    },
+    {
+      name  = "clusterName"
+      value = module.eks.cluster_name
+    },
+    {
+      name  = "region"
+      value = local.region
+    },
+    {
+      name  = "vpcId"
+      value = module.vpc.vpc_id
+    },
+  ]
 }

--- a/karpenter/eks.tf
+++ b/karpenter/eks.tf
@@ -1,13 +1,13 @@
 module "eks" {
   source  = "terraform-aws-modules/eks/aws"
-  version = "~> 20.0"
+  version = "~> 21.0"
 
-  cluster_name    = local.name
-  cluster_version = "1.29"
+  name               = local.name
+  kubernetes_version = "1.29"
 
-  cluster_endpoint_public_access = true
+  endpoint_public_access = true
 
-  cluster_addons = {
+  addons = {
     coredns = {
       configuration_values = jsonencode({
         computeType = "Fargate"
@@ -42,8 +42,8 @@ module "eks" {
   control_plane_subnet_ids = module.vpc.intra_subnets
 
   # Fargate profiles use the cluster primary security group so these are not utilized
-  create_cluster_security_group = false
-  create_node_security_group    = false
+  create_security_group      = false
+  create_node_security_group = false
 
   fargate_profiles = {
     karpenter = {

--- a/karpenter/karpenter.tf
+++ b/karpenter/karpenter.tf
@@ -4,13 +4,9 @@
 
 module "karpenter" {
   source  = "terraform-aws-modules/eks/aws//modules/karpenter"
-  version = "~> 20.0"
+  version = "~> 21.0"
 
   cluster_name = module.eks.cluster_name
-
-  # EKS Fargate currently does not support Pod Identity
-  enable_irsa            = true
-  irsa_oidc_provider_arn = module.eks.oidc_provider_arn
 
   tags = module.tags.tags
 }
@@ -27,7 +23,7 @@ resource "helm_release" "karpenter" {
   repository_username = data.aws_ecrpublic_authorization_token.token.user_name
   repository_password = data.aws_ecrpublic_authorization_token.token.password
   chart               = "karpenter"
-  version             = "1.5.0"
+  version             = "1.12.0"
   wait                = false
 
   values = [

--- a/karpenter/main.tf
+++ b/karpenter/main.tf
@@ -1,18 +1,18 @@
 terraform {
-  required_version = ">= 1.3.2"
+  required_version = ">= 1.5.7"
 
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.40"
+      version = ">= 6.0"
     }
     helm = {
       source  = "hashicorp/helm"
-      version = "~> 2.6"
+      version = "~> 3.0"
     }
     kubectl = {
       source  = "alekc/kubectl"
-      version = ">= 2.0"
+      version = ">= 2.4"
     }
   }
 
@@ -36,11 +36,11 @@ provider "aws" {
 }
 
 provider "helm" {
-  kubernetes {
+  kubernetes = {
     host                   = module.eks.cluster_endpoint
     cluster_ca_certificate = base64decode(module.eks.cluster_certificate_authority_data)
 
-    exec {
+    exec = {
       api_version = "client.authentication.k8s.io/v1beta1"
       command     = "aws"
       # This requires the awscli to be installed locally where Terraform is executed
@@ -89,7 +89,7 @@ data "aws_ecrpublic_authorization_token" "token" {}
 
 module "tags" {
   source  = "clowdhaus/tags/aws"
-  version = "~> 1.0"
+  version = "~> 2.0"
 
   application = local.name
   environment = local.environment

--- a/karpenter/vpc.tf
+++ b/karpenter/vpc.tf
@@ -1,7 +1,7 @@
 module "vpc" {
   # https://registry.terraform.io/modules/terraform-aws-modules/vpc/aws/latest
   source  = "terraform-aws-modules/vpc/aws"
-  version = "~> 5.0"
+  version = "~> 6.0"
 
   name = local.name
   cidr = local.vpc_cidr

--- a/private/eks.tf
+++ b/private/eks.tf
@@ -1,11 +1,11 @@
 module "eks" {
   source  = "terraform-aws-modules/eks/aws"
-  version = "~> 20.0"
+  version = "~> 21.0"
 
-  cluster_name    = local.name
-  cluster_version = "1.29"
+  name               = local.name
+  kubernetes_version = "1.29"
 
-  cluster_addons = {
+  addons = {
     coredns    = {}
     kube-proxy = {}
     vpc-cni    = {}
@@ -14,14 +14,11 @@ module "eks" {
   vpc_id     = module.vpc.vpc_id
   subnet_ids = module.vpc.private_subnets
 
-  eks_managed_node_group_defaults = {
-    instance_types = ["m6i.large", "m5.large", "m5n.large", "m5zn.large"]
-  }
-
   eks_managed_node_groups = {
     eks-reference-secure-1 = {
-      ami_type = "BOTTLEROCKET_x86_64"
-      platform = "bottlerocket"
+      instance_types = ["m6i.large", "m5.large", "m5n.large", "m5zn.large"]
+      ami_type       = "BOTTLEROCKET_x86_64"
+      platform       = "bottlerocket"
 
       bootstrap_extra_args = <<-EOT
         # extra args added
@@ -56,7 +53,7 @@ module "eks" {
 
 module "ebs_kms" {
   source  = "terraform-aws-modules/kms/aws"
-  version = "~> 3.0"
+  version = "~> 4.0"
 
   description = "EBS volume encryption key"
 

--- a/private/main.tf
+++ b/private/main.tf
@@ -1,10 +1,10 @@
 terraform {
-  required_version = ">= 1.3.2"
+  required_version = ">= 1.5.7"
 
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.40"
+      version = ">= 6.0"
     }
   }
 
@@ -56,7 +56,7 @@ data "aws_partition" "current" {}
 
 module "tags" {
   source  = "clowdhaus/tags/aws"
-  version = "~> 1.0"
+  version = "~> 2.0"
 
   application = local.name
   environment = local.environment

--- a/private/vpc.tf
+++ b/private/vpc.tf
@@ -4,7 +4,7 @@
 
 module "vpc" {
   source  = "terraform-aws-modules/vpc/aws"
-  version = "~> 5.0"
+  version = "~> 6.0"
 
   name = local.name
   cidr = local.vpc_cidr
@@ -273,7 +273,7 @@ module "vpc" {
 
 module "vpc_endpoints" {
   source  = "terraform-aws-modules/vpc/aws//modules/vpc-endpoints"
-  version = "~> 5.0"
+  version = "~> 6.0"
 
   vpc_id = module.vpc.vpc_id
 

--- a/self-managed-node-group/eks_default.tf
+++ b/self-managed-node-group/eks_default.tf
@@ -1,15 +1,15 @@
 module "eks_default" {
   source  = "terraform-aws-modules/eks/aws"
-  version = "~> 20.0"
+  version = "~> 21.0"
 
-  cluster_name    = "${local.name}-default"
-  cluster_version = "1.30"
+  name               = "${local.name}-default"
+  kubernetes_version = "1.30"
 
   enable_cluster_creator_admin_permissions = true
-  cluster_endpoint_public_access           = true
+  endpoint_public_access                   = true
 
   # EKS Addons
-  cluster_addons = {
+  addons = {
     coredns    = {}
     kube-proxy = {}
     vpc-cni    = {}

--- a/self-managed-node-group/main.tf
+++ b/self-managed-node-group/main.tf
@@ -1,10 +1,10 @@
 terraform {
-  required_version = ">= 1.3.2"
+  required_version = ">= 1.5.7"
 
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.40"
+      version = ">= 6.0"
     }
   }
 
@@ -52,7 +52,7 @@ data "aws_availability_zones" "available" {}
 
 module "tags" {
   source  = "clowdhaus/tags/aws"
-  version = "~> 1.0"
+  version = "~> 2.0"
 
   application = local.name
   environment = local.environment

--- a/self-managed-node-group/vpc.tf
+++ b/self-managed-node-group/vpc.tf
@@ -1,7 +1,7 @@
 module "vpc" {
   # https://registry.terraform.io/modules/terraform-aws-modules/vpc/aws/latest
   source  = "terraform-aws-modules/vpc/aws"
-  version = "~> 5.0"
+  version = "~> 6.0"
 
   name = local.name
   cidr = local.vpc_cidr

--- a/serverless/eks.tf
+++ b/serverless/eks.tf
@@ -1,15 +1,15 @@
 module "eks" {
   source  = "terraform-aws-modules/eks/aws"
-  version = "~> 20.0"
+  version = "~> 21.0"
 
-  cluster_name    = local.name
-  cluster_version = "1.29"
+  name               = local.name
+  kubernetes_version = "1.29"
 
   vpc_id     = module.vpc.vpc_id
   subnet_ids = module.vpc.private_subnets
 
   # EKS Addons
-  cluster_addons = {
+  addons = {
     coredns = {
       configuration_values = jsonencode({
         computeType = "Fargate"

--- a/serverless/main.tf
+++ b/serverless/main.tf
@@ -1,10 +1,10 @@
 terraform {
-  required_version = ">= 1.3.2"
+  required_version = ">= 1.5.7"
 
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.40"
+      version = ">= 6.0"
     }
   }
 
@@ -52,7 +52,7 @@ data "aws_availability_zones" "available" {}
 
 module "tags" {
   source  = "clowdhaus/tags/aws"
-  version = "~> 1.0"
+  version = "~> 2.0"
 
   application = local.name
   environment = local.environment

--- a/serverless/vpc.tf
+++ b/serverless/vpc.tf
@@ -1,7 +1,7 @@
 module "vpc" {
   # https://registry.terraform.io/modules/terraform-aws-modules/vpc/aws/latest
   source  = "terraform-aws-modules/vpc/aws"
-  version = "~> 5.0"
+  version = "~> 6.0"
 
   name = local.name
   cidr = local.vpc_cidr

--- a/weaviate/add-ons.tf
+++ b/weaviate/add-ons.tf
@@ -4,7 +4,7 @@
 
 module "eks_blueprints_addons" {
   source  = "aws-ia/eks-blueprints-addons/aws"
-  version = "~> 1.0"
+  version = "~> 1.23"
 
   cluster_name      = module.eks.cluster_name
   cluster_endpoint  = module.eks.cluster_endpoint
@@ -16,7 +16,7 @@ module "eks_blueprints_addons" {
 
   enable_aws_load_balancer_controller = true
   aws_load_balancer_controller = {
-    chart_version = "1.5.4"
+    chart_version = "1.17.1"
   }
   enable_metrics_server        = true
   enable_kube_prometheus_stack = false
@@ -33,7 +33,7 @@ module "eks_blueprints_addons" {
   helm_releases = {
     prometheus-adapter = {
       chart            = "prometheus-adapter"
-      chart_version    = "4.2.0"
+      chart_version    = "5.3.0"
       repository       = "https://prometheus-community.github.io/helm-charts"
       description      = "A Helm chart for k8s prometheus adapter"
       namespace        = "prometheus-adapter"
@@ -41,7 +41,7 @@ module "eks_blueprints_addons" {
     }
     weaviate = {
       chart            = "weaviate"
-      chart_version    = "16.4.0"
+      chart_version    = "17.8.1"
       repository       = "https://weaviate.github.io/weaviate-helm"
       description      = "A Helm chart for Weaviate"
       namespace        = "weaviate"

--- a/weaviate/eks.tf
+++ b/weaviate/eks.tf
@@ -4,16 +4,16 @@
 
 module "eks" {
   source  = "terraform-aws-modules/eks/aws"
-  version = "~> 20.0"
+  version = "~> 21.0"
 
-  cluster_name    = local.name
-  cluster_version = "1.29"
+  name               = local.name
+  kubernetes_version = "1.29"
 
-  cluster_endpoint_public_access = true
+  endpoint_public_access = true
 
-  cluster_addons = {
+  addons = {
     aws-ebs-csi-driver = {
-      service_account_role_arn = module.ebs_csi_driver_irsa.iam_role_arn
+      service_account_role_arn = module.ebs_csi_driver_irsa.arn
     }
     coredns    = {}
     kube-proxy = {}
@@ -111,10 +111,12 @@ module "eks" {
 }
 
 module "ebs_csi_driver_irsa" {
-  source  = "terraform-aws-modules/iam/aws//modules/iam-role-for-service-accounts-eks"
-  version = "~> 5.20"
+  source  = "terraform-aws-modules/iam/aws//modules/iam-role-for-service-accounts"
+  version = "~> 6.0"
 
-  role_name_prefix = "${module.eks.cluster_name}-ebs-csi-driver-"
+  name = "${module.eks.cluster_name}-ebs-csi-driver-"
+
+  use_name_prefix = true
 
   attach_ebs_csi_policy = true
 

--- a/weaviate/main.tf
+++ b/weaviate/main.tf
@@ -1,22 +1,22 @@
 terraform {
-  required_version = ">= 1.3.2"
+  required_version = ">= 1.5.7"
 
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.40"
+      version = ">= 6.0"
     }
     helm = {
       source  = "hashicorp/helm"
-      version = "~> 2.10"
+      version = "~> 2.17"
     }
     kubernetes = {
       source  = "hashicorp/kubernetes"
-      version = ">= 2.20"
+      version = ">= 3.0"
     }
     null = {
       source  = "hashicorp/null"
-      version = ">= 3.0"
+      version = ">= 3.3"
     }
   }
 
@@ -90,7 +90,7 @@ data "aws_availability_zones" "available" {}
 
 module "tags" {
   source  = "clowdhaus/tags/aws"
-  version = "~> 1.0"
+  version = "~> 2.0"
 
   application = local.name
   environment = local.environment

--- a/weaviate/sagemaker.tf
+++ b/weaviate/sagemaker.tf
@@ -167,7 +167,7 @@ module "sagemaker_sg" {
 
 module "s3_bucket" {
   source  = "terraform-aws-modules/s3-bucket/aws"
-  version = "~> 4.0"
+  version = "~> 5.0"
 
   bucket_prefix = "${local.name}-"
 

--- a/weaviate/vpc.tf
+++ b/weaviate/vpc.tf
@@ -1,7 +1,7 @@
 module "vpc" {
   # https://registry.terraform.io/modules/terraform-aws-modules/vpc/aws/latest
   source  = "terraform-aws-modules/vpc/aws"
-  version = "~> 5.0"
+  version = "~> 6.0"
 
   name = local.name
   cidr = local.vpc_cidr
@@ -28,7 +28,7 @@ module "vpc" {
 
 module "vpc_endpoints" {
   source  = "terraform-aws-modules/vpc/aws//modules/vpc-endpoints"
-  version = "~> 5.0"
+  version = "~> 6.0"
 
   vpc_id = module.vpc.vpc_id
 

--- a/windows/eks.tf
+++ b/windows/eks.tf
@@ -1,14 +1,14 @@
 module "eks" {
   source  = "terraform-aws-modules/eks/aws"
-  version = "~> 20.0"
+  version = "~> 21.0"
 
-  cluster_name    = local.name
-  cluster_version = "1.29"
+  name               = local.name
+  kubernetes_version = "1.29"
 
-  cluster_endpoint_public_access = true
+  endpoint_public_access = true
 
   # EKS Addons
-  cluster_addons = {
+  addons = {
     coredns    = {}
     kube-proxy = {}
     vpc-cni    = {}

--- a/windows/main.tf
+++ b/windows/main.tf
@@ -1,10 +1,10 @@
 terraform {
-  required_version = ">= 1.3.2"
+  required_version = ">= 1.5.7"
 
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.40"
+      version = ">= 6.0"
     }
   }
 
@@ -52,7 +52,7 @@ data "aws_availability_zones" "available" {}
 
 module "tags" {
   source  = "clowdhaus/tags/aws"
-  version = "~> 1.0"
+  version = "~> 2.0"
 
   application = local.name
   environment = local.environment

--- a/windows/vpc.tf
+++ b/windows/vpc.tf
@@ -1,7 +1,7 @@
 module "vpc" {
   # https://registry.terraform.io/modules/terraform-aws-modules/vpc/aws/latest
   source  = "terraform-aws-modules/vpc/aws"
-  version = "~> 5.0"
+  version = "~> 6.0"
 
   name = local.name
   cidr = local.vpc_cidr


### PR DESCRIPTION
Bumps to latest including majors across modules, providers, helm charts, GitHub Actions, and pre-commit hooks. Several majors required source migrations.

- terraform required_version ">= 1.3.2" → ">= 1.5.7" (forced by terraform-aws-modules/eks v21 floor)
- terraform-aws-modules/eks/aws ~> 19.15 / ~> 20.0 / ~> 20.4 / ~> 20.5 → ~> 21.0
- terraform-aws-modules/eks/aws//modules/karpenter ~> 20.0 → ~> 21.0
- terraform-aws-modules/vpc/aws ~> 5.0 → ~> 6.0
- terraform-aws-modules/vpc/aws//modules/vpc-endpoints ~> 5.0 → ~> 6.0
- terraform-aws-modules/iam/aws//modules/iam-role-for-service-accounts-eks ~> 5.20 → terraform-aws-modules/iam/aws//modules/iam-role-for-service-accounts ~> 6.0 (submodule renamed in iam v6)
- terraform-aws-modules/s3-bucket/aws ~> 4.0 → ~> 5.0
- terraform-aws-modules/kms/aws ~> 3.0 → ~> 4.0
- clowdhaus/tags/aws ~> 1.0 → ~> 2.0
- aws-ia/eks-blueprints-addons/aws ~> 1.0 / ~> 1.16 → ~> 1.23
- hashicorp/aws >= 5.40 → >= 6.0
- hashicorp/helm >= 2.6 / >= 2.7 / ~> 2.6 / ~> 2.10 → ~> 3.0 (held at ~> 2.17 in 4 workspaces — see note below)
- hashicorp/kubernetes >= 2.20 → >= 3.0
- alekc/kubectl >= 2.0 → >= 2.4
- hashicorp/http >= 3.3 → >= 3.6
- hashicorp/null >= 3.0 → >= 3.3
- karpenter helm chart (OCI) 1.5.0 → 1.12.0
- aws-load-balancer-controller helm chart 1.13.3 → 3.3.0 (karpenter workspace)
- nvidia-device-plugin helm chart 0.17.1 → 0.19.2
- prometheus-adapter helm chart 4.2.0 → 5.3.0 (weaviate)
- weaviate helm chart 16.4.0 → 17.8.1
- actions/checkout v4 → v6
- clowdhaus/terraform-composite-actions v1.11.1 → v1.14.0
- clowdhaus/terraform-min-max v1.3.2 → v3.0.1
- antonbabenko/pre-commit-terraform v1.91.0 → v1.106.0
- pre-commit/pre-commit-hooks v4.6.0 → v6.0.0

Migration work performed:
- EKS module v21 input renames applied in every workspace: cluster_name → name, cluster_version → kubernetes_version, cluster_addons → addons, cluster_endpoint_public_access → endpoint_public_access, create_cluster_security_group → create_security_group.
- EKS v21 removed eks_managed_node_group_defaults — inlined defaults into each named node group in cluster-autoscaler, eks-mng-gpu, inferentia, private.
- IAM v6 submodule rename + variable renames (role_name → name, role_name_prefix → name + use_name_prefix = true) and output rename (iam_role_arn → arn) in all four IRSA module callers.
- Karpenter submodule v21 removed enable_irsa / irsa_oidc_provider_arn (Pod Identity is now the default) — removed from karpenter/karpenter.tf.
- Helm provider v3 schema migration in karpenter and eks-mng-gpu (kubernetes {} → kubernetes = {}, exec {} → exec = {}, set {} blocks → set = [{}] list).

helm provider was held at ~> 2.17 in inferentia, cluster-autoscaler, karpenter-gpu, weaviate. The aws-ia/eks-blueprints-addons v1.23.0 module pins helm >= 2.9, < 3.0 (upstream is working on helm 3 support on master but has not released it). Workspaces not using that module are on helm v3. Same constraint forced weaviate/add-ons.tf to pin the ALB controller chart_version to 1.17.1 (latest 1.x) rather than chart 3.x — the wrapper module only knows the 1.x values schema.

karpenter-gpu/eks.tf previously used the now-removed manage_aws_auth_configmap / aws_auth_roles to register the Karpenter node IAM role. v21 replaces this with access_entries, but referencing module.eks_blueprints_addons.karpenter.node_iam_role_arn creates a dependency cycle with the addons module. Removed the block with a NOTE — needs operator follow-up to wire Karpenter node access via an externally-managed role or by moving Karpenter management out of aws-ia/eks-blueprints-addons.

Manual review — these have version-like values but require operator judgment:
- cluster_version / kubernetes_version is 1.27 in karpenter-gpu/eks.tf:10, 1.29 in 13 other workspaces, 1.30 in self-managed-node-group/eks_default.tf:6
- karpenter chart 1.12.0 may require migrating kubectl_manifest yaml_body from karpenter.sh/v1beta1 + karpenter.k8s.aws/v1beta1 → v1 (see karpenter/karpenter.tf NodeClass + NodePool blocks)
- neuron_device_plugin_version = "v2.17.0" in inferentia/add-ons.tf:37
- weaviate value image: tag: 1.20.0 in weaviate/add-ons.tf
- YAML manifests with image: tags — ephemeral-vol-test/deployment.yaml:17, ephemeral-vol-test/pod.yaml:8, inferentia/llama2.yaml:33, cluster-autoscaler/inflate.yaml:18, karpenter-gpu/gpu.yaml:23

Supersedes #70, #71, #74, #75, #76, #77, #78, #80, #81, #82.